### PR TITLE
BugFix for icon theme

### DIFF
--- a/mate/256x256/mimetypes/text-x-preview.icon
+++ b/mate/256x256/mimetypes/text-x-preview.icon
@@ -1,0 +1,2 @@
+[Icon Data]
+EmbeddedTextRectangle=35,19,177,236

--- a/mate/48x48/mimetypes/text-x-preview.icon
+++ b/mate/48x48/mimetypes/text-x-preview.icon
@@ -1,0 +1,2 @@
+[Icon Data]
+EmbeddedTextRectangle=9,6,31,40


### PR DESCRIPTION
This update fixes bug with plain-text thumbnails in Caja. Without this fix text from plain-text files do not displayed on thumbnails.

On branch master
Changes to be committed:

new file:   mate/256x256/mimetypes/text-x-preview.icon
new file:   mate/48x48/mimetypes/text-x-preview.icon
