### PR TITLE
fix index.theme in Menta

### DIFF
--- a/menta/index.theme
+++ b/menta/index.theme
@@ -21,7 +21,7 @@ PanelDefault=32
 PanelSizes=16,22,32,48,64,72,96,128
 
 # Directory list
-Directories=16x16/actions,16x16/apps,16x16/categories,16x16/devices,16x16/places,16x16/status,22x22/actions,22x22/apps,22x22/categories,22x22/devices,22x22/places,22x22/status,24x24/actions,24x24/apps,24x24/categories,24x24/devices,24x24/places,24x24/status,32x32/actions,,32x32/apps,32x32/categories,32x32/devices,32x32/places,32x32/status,48x48/actions,48x48/apps,48x48/categories,48x48/devices,48x48/places,48x48/status,256x256/actions,256x256/apps,256x256/categories,256x256/devices,256x256/places,256x256/status,scalable/actions,scalable/apps,scalable/devices,scalable/places,scalable/status
+Directories=16x16/actions,16x16/apps,16x16/categories,16x16/devices,16x16/places,16x16/status,22x22/actions,22x22/apps,22x22/categories,22x22/devices,22x22/places,22x22/status,24x24/actions,24x24/apps,24x24/categories,24x24/devices,24x24/places,24x24/status,32x32/actions,32x32/apps,32x32/categories,32x32/devices,32x32/places,32x32/status,48x48/actions,48x48/apps,48x48/categories,48x48/devices,48x48/places,48x48/status,256x256/actions,256x256/apps,256x256/categories,256x256/devices,256x256/places,256x256/status,scalable/actions,scalable/apps,scalable/categories,scalable/devices,scalable/places,scalable/status
 
 [16x16/actions]
 Context=Actions
@@ -70,11 +70,6 @@ Type=Fixed
 
 [22x22/devices]
 Context=Devices
-Size=22
-Type=Fixed
-
-[22x22/emblems]
-Context=Emblems
 Size=22
 Type=Fixed
 
@@ -228,6 +223,13 @@ MaxSize=512
 Type=Scalable
 
 [scalable/apps]
+Context=Applications
+Size=16
+MinSize=8
+MaxSize=512
+Type=Scalable
+
+[scalable/categories]
 Context=Applications
 Size=16
 MinSize=8


### PR DESCRIPTION
This fix the the warning about the 'size field' in a terminal.

@MDykstra
there are some open questions for me.
1. Why you are using scalable directories in index.theme file if there is no folder scalable?
2. Why you are using 'min/max scalable values' and 'Type=Scalable' for png icons in 256x256 folder?
