### PR TITLE
MATE Foundation -> GNOME Foundation

### DIFF
--- a/po/en@shaw.po
+++ b/po/en@shaw.po
@@ -1,5 +1,5 @@
 # Shavian translation for mate-icon-theme.
-# Copyright (C) 2009 The Mate Foundation.
+# Copyright (C) 2009 The Gnome Foundation.
 # Thomas Thurman <tthurman@gnome.org>, 2009.
 msgid ""
 msgstr ""

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -1,5 +1,5 @@
 # English/Canada translation of mate-icon-theme.
-# Copyright (C) 2004-2005 Adam Weinberger and the MATE Foundation
+# Copyright (C) 2004-2005 Adam Weinberger and the GNOME Foundation
 # This file is distributed under the same licence as the mate-icon-theme package.
 # Adam Weinberger <adamw@gnome.org>, 2004, 2005.
 # 

--- a/po/gnome-copyrights.txt
+++ b/po/gnome-copyrights.txt
@@ -296,7 +296,7 @@
 # Estonian translation of MATE icon theme.
 #
 # Copyright (C) 2003, 2005 Free Software Foundation, Inc.
-# Copyright (C) 2007 The MATE Project
+# Copyright (C) 2007 The GNOME Project
 # This file is distributed under the same license as the mate-icon-theme
 # package.
 #

--- a/po/gnome-copyrights.txt
+++ b/po/gnome-copyrights.txt
@@ -236,7 +236,7 @@
 
 ========== en@shaw.po ==========
 # Shavian translation for mate-icon-theme.
-# Copyright (C) 2009 The Mate Foundation.
+# Copyright (C) 2009 The Gnome Foundation.
 # Thomas Thurman <tthurman@gnome.org>, 2009.
 
 
@@ -244,7 +244,7 @@
 
 ========== en_CA.po ==========
 # English/Canada translation of mate-icon-theme.
-# Copyright (C) 2004-2005 Adam Weinberger and the MATE Foundation
+# Copyright (C) 2004-2005 Adam Weinberger and the GNOME Foundation
 # This file is distributed under the same licence as the mate-icon-theme package.
 # Adam Weinberger <adamw@gnome.org>, 2004, 2005.
 # 


### PR DESCRIPTION
I left the capitalization how it originally was:
https://github.com/GNOME/gnome-icon-theme/tree/gnome-2-30/po