### PR TITLE
Change url project's website

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ(2.53)
 
-AC_INIT([mate-icon-theme], [1.23.0], [http://www.mate-desktop.org])
+AC_INIT([mate-icon-theme], [1.23.0], [https://mate-desktop.org])
 AC_CONFIG_SRCDIR([index.theme.in.in])
 AM_EXTRA_RECURSIVE_TARGETS([clean-png-icons build-png-icons])
 


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.