### PR TITLE
preferences-system-time.png files are not generated from sources

### DIFF
--- a/mate/16x16/apps/Makefile.am
+++ b/mate/16x16/apps/Makefile.am
@@ -22,7 +22,6 @@ png_icons = \
 	preferences-system-privacy.png \
 	preferences-system-search.png \
 	preferences-system-sharing.png \
-	preferences-system-time.png \
 	preferences-system-windows.png \
 	system-file-manager.png \
 	system-software-install.png \

--- a/mate/22x22/apps/Makefile.am
+++ b/mate/22x22/apps/Makefile.am
@@ -22,7 +22,6 @@ png_icons = \
 	preferences-system-privacy.png \
 	preferences-system-search.png \
 	preferences-system-sharing.png \
-	preferences-system-time.png \
 	preferences-system-windows.png \
 	system-file-manager.png \
 	system-software-install.png \

--- a/mate/24x24/apps/Makefile.am
+++ b/mate/24x24/apps/Makefile.am
@@ -22,7 +22,6 @@ png_icons = \
 	preferences-system-privacy.png \
 	preferences-system-search.png \
 	preferences-system-sharing.png \
-	preferences-system-time.png \
 	preferences-system-windows.png \
 	system-file-manager.png \
 	system-software-install.png \

--- a/mate/256x256/apps/Makefile.am
+++ b/mate/256x256/apps/Makefile.am
@@ -21,7 +21,6 @@ png_icons = \
 	preferences-system-privacy.png \
 	preferences-system-search.png \
 	preferences-system-sharing.png \
-	preferences-system-time.png \
 	system-file-manager.png \
 	system-software-install.png \
 	system-software-update.png \

--- a/mate/32x32/apps/Makefile.am
+++ b/mate/32x32/apps/Makefile.am
@@ -22,7 +22,6 @@ png_icons = \
 	preferences-system-privacy.png \
 	preferences-system-search.png \
 	preferences-system-sharing.png \
-	preferences-system-time.png \
 	preferences-system-windows.png \
 	system-file-manager.png \
 	system-software-install.png \

--- a/mate/48x48/apps/Makefile.am
+++ b/mate/48x48/apps/Makefile.am
@@ -22,7 +22,6 @@ png_icons = \
 	preferences-system-privacy.png \
 	preferences-system-search.png \
 	preferences-system-sharing.png \
-	preferences-system-time.png \
 	preferences-system-windows.png \
 	system-file-manager.png \
 	system-software-install.png \


### PR DESCRIPTION
Test:
```shell
$ ./autogen.sh --prefix=/usr
$ make -C mate clean-png-icons build-png-icons
```